### PR TITLE
Rmagick version 4.x系に対応するためにremovedになったメソッドを修正

### DIFF
--- a/lib/rmagick/extract_object/image.rb
+++ b/lib/rmagick/extract_object/image.rb
@@ -23,7 +23,7 @@ module Magick
         base_image = @image if base_image.nil?
 
         image = Magick::ImageList.new << base_image
-        image.alpha = Magick::ActivateAlphaChannel
+        image.alpha Magick::ActivateAlphaChannel
         image.fx("r", Magick::AlphaChannel).composite(mask_image, Magick::CenterGravity, Magick::CopyOpacityCompositeOp)
       end
 


### PR DESCRIPTION
rmagickを最新の4.1.2にアップデートしたところ、rmagickに依存していたrmagick-extract_objectのコードが壊れてしまったので、rmagickの最新をサポートするようにしたいと思っています。