### PR TITLE
Rmagick version 4.x系に対応するためにremovedになったメソッドを修正

### DIFF
--- a/lib/rmagick/extract_object/image.rb
+++ b/lib/rmagick/extract_object/image.rb
@@ -24,7 +24,7 @@ module Magick
 
         image = Magick::ImageList.new << base_image
         image.alpha Magick::ActivateAlphaChannel
-        image.fx("r", Magick::AlphaChannel).composite(mask_image, Magick::CenterGravity, Magick::CopyOpacityCompositeOp)
+        image.fx("r", Magick::AlphaChannel).composite(mask_image, Magick::CenterGravity, Magick::CopyAlphaCompositeOp)
       end
 
       def edge

--- a/lib/rmagick/extract_object/image.rb
+++ b/lib/rmagick/extract_object/image.rb
@@ -23,7 +23,7 @@ module Magick
         base_image = @image if base_image.nil?
 
         image = Magick::ImageList.new << base_image
-        image.alpha = Magick::ActivateAlphaChannel
+        image.alpha Magick::ActivateAlphaChannel
         image.fx("r", Magick::AlphaChannel).composite(mask_image, Magick::CenterGravity, Magick::CopyOpacityCompositeOp)
       end
 

--- a/lib/rmagick/extract_object/version.rb
+++ b/lib/rmagick/extract_object/version.rb
@@ -1,5 +1,5 @@
 module Magick
   module ExtractObject
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/rmagick-extract_object.gemspec
+++ b/rmagick-extract_object.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rmagick', '> 2.13'
+  spec.add_dependency 'rmagick', '> 3.0.0'
   spec.add_dependency 'mimemagic', '~> 0.3.0'
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
rmagickを最新の4.1.2にアップデートしたところ、rmagickに依存していたrmagick-extract_objectのコードが壊れてしまったので、rmagickの最新バージョンをサポートするようにしたいです。